### PR TITLE
[Performance] Optimized entity list loads

### DIFF
--- a/src/main/java/ca/utoronto/fitbook/adapter/persistence/firebase/GenericFirebaseRepository.java
+++ b/src/main/java/ca/utoronto/fitbook/adapter/persistence/firebase/GenericFirebaseRepository.java
@@ -1,0 +1,64 @@
+package ca.utoronto.fitbook.adapter.persistence.firebase;
+
+import ca.utoronto.fitbook.application.exceptions.EntityNotFoundException;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+@RequiredArgsConstructor
+public abstract class GenericFirebaseRepository
+{
+    protected abstract Firestore getFirestore();
+    protected abstract String getCollectionName();
+
+    private ApiFuture<DocumentSnapshot> getFutureDocumentById(String id) {
+        return getFirestore().collection(getCollectionName()).document(id).get();
+    }
+
+    /**
+     * Gets a document snapshot from the database by id
+     *
+     * @param id The id of the document
+     * @return Returns a snapshot of the document
+     * @throws EntityNotFoundException Throws when the document is not found
+     */
+    protected DocumentSnapshot getDocumentById(String id) throws EntityNotFoundException {
+        ApiFuture<DocumentSnapshot> future = getFutureDocumentById(id);
+        try {
+            DocumentSnapshot document = future.get();
+            if (document.exists())
+                return document;
+            throw new EntityNotFoundException(id);
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Fetches a list of document snapshots from the database by id asynchronously
+     *
+     * @param idList A list of ids to fetch from the database
+     * @return Returns a list of document snapshots
+     * @throws EntityNotFoundException Throws when one of the documents are not found
+     */
+    protected List<DocumentSnapshot> getDocumentList(List<String> idList) throws EntityNotFoundException {
+        try {
+            // Asynchronously load all the entities by Id
+            List<ApiFuture<DocumentSnapshot>> futuresList = new ArrayList<>();
+            for (String id : idList) {
+                futuresList.add(getFutureDocumentById(id));
+            }
+
+            // Wait for all documents to resolve and return that list
+            return ApiFutures.allAsList(futuresList).get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/ca/utoronto/fitbook/adapter/persistence/firebase/PostFirebaseRepository.java
+++ b/src/main/java/ca/utoronto/fitbook/adapter/persistence/firebase/PostFirebaseRepository.java
@@ -6,11 +6,9 @@ import ca.utoronto.fitbook.application.port.in.LoadPaginatedPosts;
 import ca.utoronto.fitbook.application.port.in.LoadPostListPort;
 import ca.utoronto.fitbook.application.port.in.LoadPostPort;
 import ca.utoronto.fitbook.application.port.out.SavePostPort;
+import ca.utoronto.fitbook.entity.Post;
 import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.*;
-import ca.utoronto.fitbook.entity.Post;
-import com.google.cloud.firestore.Firestore;
-import com.google.cloud.firestore.WriteResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -20,16 +18,27 @@ import java.util.concurrent.ExecutionException;
 
 @Repository
 @RequiredArgsConstructor
-public class PostFirebaseRepository implements GenericRepository<Post>,
+public class PostFirebaseRepository
+        extends GenericFirebaseRepository
+        implements GenericRepository<Post>,
         LoadPostPort,
         SavePostPort,
         LoadPostListPort,
         LoadPaginatedPosts
 {
 
+    private static final String COLLECTION_NAME = "posts";
     private final Firestore firestore;
 
-    private static final String COLLECTION_NAME = "posts";
+    @Override
+    protected Firestore getFirestore() {
+        return firestore;
+    }
+
+    @Override
+    protected String getCollectionName() {
+        return COLLECTION_NAME;
+    }
 
 
     /**
@@ -39,16 +48,7 @@ public class PostFirebaseRepository implements GenericRepository<Post>,
      */
     @Override
     public Post getById(String id) throws EntityNotFoundException {
-        ApiFuture<DocumentSnapshot> future = firestore.collection(COLLECTION_NAME).document(id).get();
-        try {
-            DocumentSnapshot document = future.get();
-            if (document.exists()) {
-                return document.toObject(Post.class);
-            }
-            throw new EntityNotFoundException(id);
-        } catch (InterruptedException | ExecutionException e) {
-            throw new RuntimeException(e);
-        }
+        return getDocumentById(id).toObject(Post.class);
     }
 
     /**
@@ -105,8 +105,11 @@ public class PostFirebaseRepository implements GenericRepository<Post>,
     @Override
     public List<Post> loadPostList(List<String> postIds) throws EntityNotFoundException {
         List<Post> postList = new ArrayList<>();
-        for (String id : postIds) {
-            postList.add(getById(id));
+        List<DocumentSnapshot> postDocumentList = getDocumentList(postIds);
+        for (DocumentSnapshot document : postDocumentList) {
+            if (!document.exists())
+                throw new EntityNotFoundException(document.getId());
+            postList.add(document.toObject(Post.class));
         }
         return postList;
     }

--- a/src/main/java/ca/utoronto/fitbook/adapter/persistence/localmemory/UserLocalMemoryRepository.java
+++ b/src/main/java/ca/utoronto/fitbook/adapter/persistence/localmemory/UserLocalMemoryRepository.java
@@ -2,14 +2,17 @@ package ca.utoronto.fitbook.adapter.persistence.localmemory;
 
 import ca.utoronto.fitbook.adapter.persistence.GenericRepository;
 import ca.utoronto.fitbook.application.exceptions.EntityNotFoundException;
+import ca.utoronto.fitbook.application.port.in.LoadUserListPort;
 import ca.utoronto.fitbook.application.port.in.LoadUserPort;
 import ca.utoronto.fitbook.application.port.out.SaveUserPort;
 import ca.utoronto.fitbook.entity.User;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
-public class UserLocalMemoryRepository implements GenericRepository<User>, LoadUserPort, SaveUserPort
+public class UserLocalMemoryRepository implements GenericRepository<User>, LoadUserPort, SaveUserPort, LoadUserListPort
 {
     private static final Map<String, User> datastore = new HashMap<>();
 
@@ -55,5 +58,19 @@ public class UserLocalMemoryRepository implements GenericRepository<User>, LoadU
     @Override
     public void saveUser(User user) {
         save(user);
+    }
+
+    /**
+     * @param userIds The user ids to be fetched
+     * @return A list of users
+     * @throws EntityNotFoundException If a single user is not found
+     */
+    @Override
+    public List<User> loadUserList(List<String> userIds) throws EntityNotFoundException {
+        List<User> userList = new ArrayList<>();
+        for (String id : userIds) {
+            userList.add(getById(id));
+        }
+        return userList;
     }
 }

--- a/src/main/java/ca/utoronto/fitbook/application/port/in/LoadUserListPort.java
+++ b/src/main/java/ca/utoronto/fitbook/application/port/in/LoadUserListPort.java
@@ -1,0 +1,11 @@
+package ca.utoronto.fitbook.application.port.in;
+
+import ca.utoronto.fitbook.application.exceptions.EntityNotFoundException;
+import ca.utoronto.fitbook.entity.User;
+
+import java.util.List;
+
+public interface LoadUserListPort
+{
+    List<User> loadUserList(List<String> userIds) throws EntityNotFoundException;
+}


### PR DESCRIPTION
Previously we have been loading lists of entities synchronously by waiting for each load to finish before we fetch the next entity in a list.

This PR brings the performance improvement of fetching the whole list asynchronously and then collecting them all at the end.

I have measured improvements in speed up to 50x, especially for code that fetches a lot of data from Firebase.

[Created a shared generic firebase repository class](https://github.com/CSC207-2022F-UofT/course-project-fitbook/commit/33f43be979bbf0031aecb65c279c8a49f0b50f90) (This generic repository implementation contains the optimized batching code).

[Implemented the generic repository across repos](https://github.com/CSC207-2022F-UofT/course-project-fitbook/commit/582cc613f0182c56e54bef114ca2244951b73582)

[Added a LoadUserListPort for consistency](https://github.com/CSC207-2022F-UofT/course-project-fitbook/commit/094e8d62fa08376f637971cf4a97be8a60352f01)